### PR TITLE
Add fruit ranking functionality with FruitRankEntry, FruitRankEntryEntity, and related service and controller

### DIFF
--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/GetFruitRankingController.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/GetFruitRankingController.java
@@ -1,0 +1,22 @@
+package com.github.yamay0.adapter.in.web;
+
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+import com.github.yamay0.application.port.in.GetFruitRankUseCase;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import java.util.List;
+
+@Path("/fruit-ranking")
+public class GetFruitRankingController {
+    private final GetFruitRankUseCase getFruitRankUseCase;
+
+    public GetFruitRankingController(GetFruitRankUseCase getFruitRankUseCase) {
+        this.getFruitRankUseCase = getFruitRankUseCase;
+    }
+
+    @GET
+    public List<FruitRankEntry> getFruitRanking() {
+        return getFruitRankUseCase.execute();
+    }
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/GetFruitRankingController.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/GetFruitRankingController.java
@@ -4,10 +4,13 @@ import com.github.yamay0.application.domain.model.FruitRankEntry;
 import com.github.yamay0.application.port.in.GetFruitRankUseCase;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
 
 @Path("/fruit-ranking")
+@Produces(MediaType.APPLICATION_JSON)
 public class GetFruitRankingController {
     private final GetFruitRankUseCase getFruitRankUseCase;
 

--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/FruitRankEntryEntity.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/FruitRankEntryEntity.java
@@ -1,0 +1,18 @@
+package com.github.yamay0.adapter.out.persistence;
+
+import com.github.yamay0.application.domain.model.Fruit;
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record FruitRankEntryEntity(
+        Fruit fruit,
+        Long count) {
+
+    public FruitRankEntry toFruitRankEntry() {
+        return new FruitRankEntry(
+                fruit,
+                count != null ? count : 0L
+        );
+    }
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/GetFruitRankAdapter.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/GetFruitRankAdapter.java
@@ -1,0 +1,23 @@
+package com.github.yamay0.adapter.out.persistence;
+
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+import com.github.yamay0.application.port.out.GetFruitRankPort;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+
+@ApplicationScoped
+public class GetFruitRankAdapter implements GetFruitRankPort {
+    private final VoteRepository voteRepository;
+
+    public GetFruitRankAdapter(VoteRepository voteRepository) {
+        this.voteRepository = voteRepository;
+    }
+
+    @Override
+    public List<FruitRankEntry> getRankedFruits() {
+        return voteRepository.getRankedFruits().stream()
+                .map(FruitRankEntryEntity::toFruitRankEntry)
+                .toList();
+    }
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/VoteRepository.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/VoteRepository.java
@@ -1,8 +1,20 @@
 package com.github.yamay0.adapter.out.persistence;
 
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.List;
+
 @ApplicationScoped
 public class VoteRepository implements PanacheRepositoryBase<VoteEntity, VoteId> {
+    public List<FruitRankEntryEntity> getRankedFruits() {
+        PanacheQuery<FruitRankEntryEntity> query = find("""
+                select v.fruit as fruit, count(v) as count
+                from VoteEntity v
+                group by v.fruit
+                order by count(v) desc
+                """).project(FruitRankEntryEntity.class);
+        return query.stream().toList();
+    }
 }

--- a/quarkus-app/src/main/java/com/github/yamay0/application/domain/model/FruitRankEntry.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/domain/model/FruitRankEntry.java
@@ -1,0 +1,15 @@
+package com.github.yamay0.application.domain.model;
+
+public record FruitRankEntry(
+        Fruit fruit,
+        long count
+) {
+    public FruitRankEntry {
+        if (fruit == null) {
+            throw new IllegalArgumentException("Fruit cannot be null");
+        }
+        if (count < 0) {
+            throw new IllegalArgumentException("Count cannot be negative");
+        }
+    }
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/application/domain/service/GetFruitRankService.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/domain/service/GetFruitRankService.java
@@ -1,0 +1,22 @@
+package com.github.yamay0.application.domain.service;
+
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+import com.github.yamay0.application.port.in.GetFruitRankUseCase;
+import com.github.yamay0.application.port.out.GetFruitRankPort;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+
+@ApplicationScoped
+public class GetFruitRankService implements GetFruitRankUseCase {
+    private final GetFruitRankPort getFruitRankPort;
+
+    public GetFruitRankService(GetFruitRankPort getFruitRankPort) {
+        this.getFruitRankPort = getFruitRankPort;
+    }
+
+    @Override
+    public List<FruitRankEntry> execute() {
+        return getFruitRankPort.getRankedFruits();
+    }
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/application/port/in/GetFruitRankUseCase.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/port/in/GetFruitRankUseCase.java
@@ -1,0 +1,9 @@
+package com.github.yamay0.application.port.in;
+
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+
+import java.util.List;
+
+public interface GetFruitRankUseCase {
+    List<FruitRankEntry> execute();
+}

--- a/quarkus-app/src/main/java/com/github/yamay0/application/port/out/GetFruitRankPort.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/port/out/GetFruitRankPort.java
@@ -1,0 +1,9 @@
+package com.github.yamay0.application.port.out;
+
+import com.github.yamay0.application.domain.model.FruitRankEntry;
+
+import java.util.List;
+
+public interface GetFruitRankPort {
+    List<FruitRankEntry> getRankedFruits();
+}


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the fruit ranking data through a RESTful web service. The main changes include the addition of a new controller, a service, and a domain model to support this functionality.

Key changes:

### Controller Addition:
* [`quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/GetFruitRankingController.java`](diffhunk://#diff-23979e5c115e4b222ba3b5aeb88691f0ac3605e9866afbdd04d364133b008f6fR1-R25): Added a new REST controller `GetFruitRankingController` to handle HTTP GET requests for fruit ranking data.

### Domain Model:
* [`quarkus-app/src/main/java/com/github/yamay0/application/domain/model/FruitRankEntry.java`](diffhunk://#diff-d1647f1f11823d3aaf6dfa0a06c0c5ff854aa8ce9769bc45b76ae1a28f5f3261R1-R15): Introduced a new domain model `FruitRankEntry` to represent the fruit ranking data, ensuring that the `fruit` is not null and `count` is non-negative.

### Service Implementation:
* [`quarkus-app/src/main/java/com/github/yamay0/application/domain/service/GetFruitRankService.java`](diffhunk://#diff-adf79fd326d7d25e69a4715fee3343b06c3fd0da450c63d14a5a2bc5744b38e7R1-R22): Implemented the `GetFruitRankService` class to provide the business logic for retrieving the fruit ranking data.

### Use Case Interface:
* [`quarkus-app/src/main/java/com/github/yamay0/application/port/in/GetFruitRankUseCase.java`](diffhunk://#diff-9a3f899d02d9a6f71c413e5737d51294612e747bbd24b4bc1a2b22000a4a50f6R1-R9): Defined the `GetFruitRankUseCase` interface to abstract the use case of getting fruit rankings.