### PR TITLE
Add HTTP endpoint annotation to VoteFruitControllerTest and simplify post request paths

### DIFF
--- a/quarkus-app/src/test/java/com/github/yamay0/adapter/in/web/VoteFruitControllerTest.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/adapter/in/web/VoteFruitControllerTest.java
@@ -1,6 +1,7 @@
 package com.github.yamay0.adapter.in.web;
 
 import com.github.yamay0.application.domain.model.Fruit;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 
 @QuarkusTest
+@TestHTTPEndpoint(VoteFruitController.class)
 class VoteFruitControllerTest {
     @Test
     @DisplayName("投票が成功すること")
@@ -18,7 +20,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(204);
     }
@@ -29,7 +31,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(null, "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -40,7 +42,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(), "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -51,7 +53,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), null))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -62,7 +64,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), ""))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }


### PR DESCRIPTION
This pull request includes updates to the `VoteFruitControllerTest` class to simplify the endpoint URL specification and improve the test setup.

Changes to simplify endpoint URL specification:

* Added `@TestHTTPEndpoint` annotation to specify the `VoteFruitController` class as the endpoint for the tests.

Improvements to test setup:

* Removed explicit endpoint URL `/vote-fruit` from the `post` method calls in the test methods, relying on the `@TestHTTPEndpoint` annotation instead. [[1]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91R15-R23) [[2]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L32-R34) [[3]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L43-R45) [[4]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L54-R56) [[5]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L65-R67)