### PR TITLE
Refactor controller naming and add integration tests for vote and rank features

### DIFF
--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/FruitRankController.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/in/web/FruitRankController.java
@@ -9,12 +9,12 @@ import jakarta.ws.rs.core.MediaType;
 
 import java.util.List;
 
-@Path("/fruit-ranking")
+@Path("/fruit-rank")
 @Produces(MediaType.APPLICATION_JSON)
-public class GetFruitRankingController {
+public class FruitRankController {
     private final GetFruitRankUseCase getFruitRankUseCase;
 
-    public GetFruitRankingController(GetFruitRankUseCase getFruitRankUseCase) {
+    public FruitRankController(GetFruitRankUseCase getFruitRankUseCase) {
         this.getFruitRankUseCase = getFruitRankUseCase;
     }
 

--- a/quarkus-app/src/test/java/com/github/yamay0/adapter/in/web/VoteFruitControllerTest.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/adapter/in/web/VoteFruitControllerTest.java
@@ -1,6 +1,7 @@
 package com.github.yamay0.adapter.in.web;
 
 import com.github.yamay0.application.domain.model.Fruit;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 
 @QuarkusTest
+@TestHTTPEndpoint(VoteFruitController.class)
 class VoteFruitControllerTest {
     @Test
     @DisplayName("投票が成功すること")
@@ -18,7 +20,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(204);
     }
@@ -29,7 +31,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(null, "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -40,7 +42,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(), "userId"))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -51,7 +53,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), null))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }
@@ -62,7 +64,7 @@ class VoteFruitControllerTest {
         given()
                 .contentType(ContentType.JSON)
                 .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), ""))
-                .when().post("/vote-fruit")
+                .when().post()
                 .then()
                 .statusCode(400);
     }

--- a/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankIntegrationTest.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.github.yamay0.scenario;
+
+import com.github.yamay0.adapter.in.web.VoteFruitRequest;
+import com.github.yamay0.application.domain.model.Fruit;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(VoteAndRankScenarioProfile.class)
+public class VoteAndRankIntegrationTest {
+    @Test
+    @TestTransaction
+    @DisplayName("複数ユーザーによる投票とランキングの取得が正しく行われること")
+    public void testVoteAndRank() {
+        // 投票1
+        given()
+                .contentType(ContentType.JSON)
+                .body(new VoteFruitRequest(List.of(Fruit.BANANA, Fruit.APPLE), "user1"))
+                .when().post("/vote-fruit")
+                .then()
+                .statusCode(204);
+        // 投票2
+        given()
+                .contentType(ContentType.JSON)
+                .body(new VoteFruitRequest(List.of(Fruit.APPLE, Fruit.ORANGE), "user2"))
+                .when().post("/vote-fruit")
+                .then()
+                .statusCode(204);
+        // 投票3
+        given()
+                .contentType(ContentType.JSON)
+                .body(new VoteFruitRequest(List.of(Fruit.APPLE, Fruit.BANANA), "user3"))
+                .when().post("/vote-fruit")
+                .then()
+                .statusCode(204);
+
+        // ランキング取得
+        given()
+                .contentType(ContentType.JSON)
+                .when().get("/fruit-rank")
+                .then()
+                .statusCode(200)
+                .body("[0].fruit", equalTo(Fruit.APPLE.toString()))
+                .body("[0].count", equalTo(3))
+                .body("[1].fruit", equalTo(Fruit.BANANA.toString()))
+                .body("[1].count", equalTo(2))
+                .body("[2].fruit", equalTo(Fruit.ORANGE.toString()))
+                .body("[2].count", equalTo(1));
+    }
+}

--- a/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankScenarioProfile.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankScenarioProfile.java
@@ -1,0 +1,6 @@
+package com.github.yamay0.scenario;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class VoteAndRankScenarioProfile implements QuarkusTestProfile {
+}


### PR DESCRIPTION
This pull request includes several changes to the Quarkus application, primarily focusing on renaming a controller, updating test endpoints, and adding new integration tests. Below are the most important changes:

### Controller Renaming:
* Renamed `GetFruitRankingController` to `FruitRankController` and updated the endpoint path from `/fruit-ranking` to `/fruit-rank`.

### Test Endpoint Updates:
* Added `@TestHTTPEndpoint` annotation to `VoteFruitControllerTest` and removed explicit endpoint paths from the `post` method calls. [[1]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91R4) [[2]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91R15-R23) [[3]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L32-R34) [[4]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L43-R45) [[5]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L54-R56) [[6]](diffhunk://#diff-cf3906a232ad973d35a8d41532f45b7b703ad30fced46156d586b6eff3841c91L65-R67)

### Integration Tests:
* Added a new integration test `VoteAndRankIntegrationTest` to verify voting and ranking functionalities with multiple users.
* Introduced `VoteAndRankScenarioProfile` to support the new integration test.