### PR TITLE
Implement voting logic to allow users to vote only on unvoted fruits

### DIFF
--- a/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/VoteFruitAdapter.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/adapter/out/persistence/VoteFruitAdapter.java
@@ -17,4 +17,10 @@ public class VoteFruitAdapter implements VoteFruitPort {
     public void vote(Fruit fruits, UserId userId) {
         voteRepository.persist(VoteEntity.from(fruits, userId));
     }
+
+    @Override
+    public boolean hasAlreadyVoted(Fruit fruit, UserId userId) {
+        VoteEntity voteEntity = VoteEntity.from(fruit, userId);
+        return voteRepository.isPersistent(voteEntity);
+    }
 }

--- a/quarkus-app/src/main/java/com/github/yamay0/application/domain/service/VoteFruitService.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/domain/service/VoteFruitService.java
@@ -31,6 +31,8 @@ class VoteFruitService implements VoteFruitUseCase {
         if (uniqueFruits.size() != fruits.size()) {
             throw new IllegalArgumentException("Fruits must be unique");
         }
-        fruits.forEach(fruit -> voteFruitPort.vote(fruit, userId));
+        fruits.stream()
+                .filter(fruit -> !voteFruitPort.hasAlreadyVoted(fruit, userId))
+                .forEach(fruit -> voteFruitPort.vote(fruit, userId));
     }
 }

--- a/quarkus-app/src/main/java/com/github/yamay0/application/port/out/VoteFruitPort.java
+++ b/quarkus-app/src/main/java/com/github/yamay0/application/port/out/VoteFruitPort.java
@@ -5,4 +5,6 @@ import com.github.yamay0.application.domain.model.UserId;
 
 public interface VoteFruitPort {
     void vote(Fruit fruits, UserId userId);
+
+    boolean hasAlreadyVoted(Fruit fruit, UserId userId);
 }

--- a/quarkus-app/src/test/java/com/github/yamay0/application/domain/service/VoteFruitServiceTest.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/application/domain/service/VoteFruitServiceTest.java
@@ -89,4 +89,28 @@ class VoteFruitServiceTest {
         assertThrows(IllegalArgumentException.class, () -> sut.execute(fruits, null));
         verifyNoInteractions(voteFruitPort);
     }
+
+    @Test
+    @DisplayName("同じユーザーによる複数回の投票の場合に、未投票のFruitに対してのみ追加で投票されること")
+    void testExecuteWithAlreadyVotedFruits() {
+        // given
+        List<Fruit> fruits = List.of(
+                Fruit.BANANA,
+                Fruit.APPLE,
+                Fruit.GRAPE
+        );
+        UserId userId = new UserId("test-user-id");
+
+        when(voteFruitPort.hasAlreadyVoted(Fruit.BANANA, userId)).thenReturn(true);
+        when(voteFruitPort.hasAlreadyVoted(Fruit.APPLE, userId)).thenReturn(false);
+        when(voteFruitPort.hasAlreadyVoted(Fruit.GRAPE, userId)).thenReturn(false);
+
+        // when
+        sut.execute(fruits, userId);
+
+        // then
+        verify(voteFruitPort).vote(Fruit.APPLE, userId);
+        verify(voteFruitPort).vote(Fruit.GRAPE, userId);
+        verify(voteFruitPort, never()).vote(Fruit.BANANA, userId);
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `VoteFruitService` and its corresponding test class to ensure that a user can only vote for fruits they haven't already voted for. The most important changes include modifying the voting logic in the service and adding a new test case to verify this behavior.

Changes in voting logic:

* [`quarkus-app/src/main/java/com/github/yamay0/application/domain/service/VoteFruitService.java`](diffhunk://#diff-f0b6b3769673c528767cf854dbb02f7d2f23af907f40580732f781352c855e88L34-R36): Updated the `execute` method to filter out fruits that the user has already voted for before proceeding with the voting action.

Updates to tests:

* [`quarkus-app/src/test/java/com/github/yamay0/application/domain/service/VoteFruitServiceTest.java`](diffhunk://#diff-559fa467059ef3fc9435d4c954eb31f524a58e4710b5ba1be057c0f9b33f2940R92-R115): Added a new test case `testExecuteWithAlreadyVotedFruits` to verify that the service only votes for fruits that the user hasn't already voted for.