### PR TITLE
Add native test execution to CI workflow for main branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,9 @@ jobs:
       - name: Build and run tests
         working-directory: ./quarkus-app
         run: ./gradlew build
+
+      - name: Run testNative
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: ./quarkus-app
+        run: |
+          ./gradlew testNative


### PR DESCRIPTION
This pull request includes an update to the CI workflow configuration to improve the testing process.

Enhancements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR29-R34): Added a new job step to run `testNative` only when a push event occurs on the `main` branch.