### PR TITLE
Add test case for invalid fruit voting scenario in VoteAndRankScenarioTest

### DIFF
--- a/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankScenarioTest.java
+++ b/quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankScenarioTest.java
@@ -28,6 +28,13 @@ public class VoteAndRankScenarioTest {
                 .when().post("/vote-fruit")
                 .then()
                 .statusCode(204);
+        // 無効な投票
+        given()
+                .contentType(ContentType.JSON)
+                .body(new VoteFruitRequest(List.of(Fruit.BANANA), "user1"))
+                .when().post("/vote-fruit")
+                .then()
+                .statusCode(204);
         // 投票2
         given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION
This pull request includes an important change to the `VoteAndRankScenarioTest` test file to handle invalid votes. The change adds a new test case to ensure that the system correctly processes an invalid vote without causing errors.

Testing improvements:

* [`quarkus-app/src/test/java/com/github/yamay0/scenario/VoteAndRankScenarioTest.java`](diffhunk://#diff-4bf9c7081e8839704caa4661426140e4613eceff5a6c149f562f9c9fb1db03b4R31-R37): Added a new test case to handle invalid votes by submitting a vote with a single fruit and verifying that the system responds with a status code of 204.